### PR TITLE
Add player and weapon color funcs to shared

### DIFF
--- a/lua/starfall/libs_sh/ply.lua
+++ b/lua/starfall/libs_sh/ply.lua
@@ -2,7 +2,7 @@ return function( instance )
 
 local checktype = instance.CheckType
 local player_methods = instance.Types.Player.Methods
-local colwrap = instance.Types.Color.Wrap
+local colorwrap = instance.Types.Color.Wrap
 local weapon_methods = instance.Types.Weapon.Methods
 local ply_meta, punwrap = instance.Types.Player, instance.Types.Player.Unwrap
 local builtins_library = instance.env
@@ -67,8 +67,8 @@ end
 function player_methods:getPlayerColor()
     checktype( self, ply_meta )
     local ply = getPly( self )
-    local color = colwrap( ply:GetPlayerColor() )
-    return color
+    
+    return colorwrap( ply:GetPlayerColor() )
 end
 
 --- Gets the vector of a player's weapon color.
@@ -76,8 +76,8 @@ end
 function player_methods:getWeaponColor()
     checktype( self, ply_meta )
     local ply = getPly( self )
-    local color = colwrap( ply:GetWeaponColor() )
-    return color
+    
+    return colorwrap( ply:GetWeaponColor() )
 end
 
 --- Gets the name (string ID) of an ammo, given an ID. Refer to the keys given from the Player:getAmmo() table for numeric IDs.

--- a/lua/starfall/libs_sh/ply.lua
+++ b/lua/starfall/libs_sh/ply.lua
@@ -2,11 +2,8 @@ return function( instance )
 
 local checktype = instance.CheckType
 local player_methods = instance.Types.Player.Methods
-<<<<<<< HEAD
 local types = instance.Types
 local weapon_methods = instance.Types.Weapon.Methods
-=======
->>>>>>> bc89a42d0e3746a913344d9d3c5e4d5ac2b8cb21
 local ply_meta, punwrap = instance.Types.Player, instance.Types.Player.Unwrap
 local builtins_library = instance.env
 

--- a/lua/starfall/libs_sh/ply.lua
+++ b/lua/starfall/libs_sh/ply.lua
@@ -3,6 +3,7 @@ return function( instance )
 
 local checktype = instance.CheckType
 local player_methods = instance.Types.Player.Methods
+local types = instance.Types
 local weapon_methods = instance.Types.Weapon.Methods
 local ply_meta, punwrap = instance.Types.Player, instance.Types.Player.Unwrap
 local builtins_library = instance.env
@@ -79,8 +80,8 @@ end
 function player_methods:getPlayerColor()
     checktype( self, ply_meta )
     local ply = getPly( self )
-
-    return ply:GetPlayerColor()
+    local color = types.Color.Wrap( ply:GetPlayerColor() )
+    return
 end
 
 
@@ -89,8 +90,8 @@ end
 function player_methods:getWeaponColor()
     checktype( self, ply_meta )
     local ply = getPly( self )
-
-    return ply:GetWeaponColor()
+    local color = types.Color.Wrap( ply:GetWeaponColor() )
+    return color
 end
 
 

--- a/lua/starfall/libs_sh/ply.lua
+++ b/lua/starfall/libs_sh/ply.lua
@@ -2,7 +2,7 @@ return function( instance )
 
 local checktype = instance.CheckType
 local player_methods = instance.Types.Player.Methods
-local types = instance.Types
+local colwrap = instance.Types.Color.Wrap
 local weapon_methods = instance.Types.Weapon.Methods
 local ply_meta, punwrap = instance.Types.Player, instance.Types.Player.Unwrap
 local builtins_library = instance.env
@@ -67,8 +67,8 @@ end
 function player_methods:getPlayerColor()
     checktype( self, ply_meta )
     local ply = getPly( self )
-    local color = types.Color.Wrap( ply:GetPlayerColor() )
-    return
+    local color = colwrap( ply:GetPlayerColor() )
+    return color
 end
 
 --- Gets the vector of a player's weapon color.
@@ -76,7 +76,7 @@ end
 function player_methods:getWeaponColor()
     checktype( self, ply_meta )
     local ply = getPly( self )
-    local color = types.Color.Wrap( ply:GetWeaponColor() )
+    local color = colwrap( ply:GetWeaponColor() )
     return color
 end
 

--- a/lua/starfall/libs_sh/ply.lua
+++ b/lua/starfall/libs_sh/ply.lua
@@ -62,8 +62,8 @@ function player_methods:getAmmo()
     return ply:GetAmmo()
 end
 
---- Gets the vector of a player's color.
--- @return The vector of a player's color
+--- Gets a valid player's color.
+-- @return The playermodel color of a given player
 function player_methods:getPlayerColor()
     checktype( self, ply_meta )
     local ply = getPly( self )
@@ -71,8 +71,8 @@ function player_methods:getPlayerColor()
     return colorwrap( ply:GetPlayerColor() )
 end
 
---- Gets the vector of a player's weapon color.
--- @return the vector of a player's weapon color 
+--- Gets a valid player's weapon color.
+-- @return the phygun weapon color of a given player
 function player_methods:getWeaponColor()
     checktype( self, ply_meta )
     local ply = getPly( self )

--- a/lua/starfall/libs_sh/ply.lua
+++ b/lua/starfall/libs_sh/ply.lua
@@ -74,6 +74,26 @@ function player_methods:getAmmo()
 end
 
 
+--- Gets the vector of a player's color.
+-- @return The vector of a player's color
+function player_methods:getPlayerColor()
+    checktype( self, ply_meta )
+    local ply = getPly( self )
+
+    return ply:GetPlayerColor()
+end
+
+
+--- Gets the vector of a player's weapon color.
+-- @return the vector of a player's weapon color 
+function player_methods:getWeaponColor()
+    checktype( self, ply_meta )
+    local ply = getPly( self )
+
+    return ply:GetWeaponColor()
+end
+
+
 --- Gets the name (string ID) of an ammo, given an ID. Refer to the keys given from the Player:getAmmo() table for numeric IDs.
 -- @param number ID
 -- @return The name of the given ammo ID

--- a/lua/starfall/libs_sh/pvp.lua
+++ b/lua/starfall/libs_sh/pvp.lua
@@ -9,7 +9,7 @@ return function( instance )
 local pvp_library = instance.Libraries.pvp
 local checktype = instance.CheckType
 local player_methods = instance.Types.Player.Methods
-local ply_meta, punwrap = instance.Types.Player, instance.Types.Player.Unwrap
+local ply_meta, punwrap, plywrap = instance.Types.Player, instance.Types.Player.Unwrap, instance.Types.Player.Wrap
 
 local function getPly( this )
     local ent = punwrap( this )
@@ -42,7 +42,7 @@ function pvp_library.getPvpers()
 
     for _, ply in pairs( player.GetHumans() ) do
         if ply:GetNWBool( "CFC_PvP_Mode", false ) then
-            table.insert( pvpers, ply )
+            table.insert( pvpers, plywrap(ply) )
         end
     end
 
@@ -56,7 +56,7 @@ function pvp_library.getBuilders()
 
     for _, ply in pairs( player.GetHumans() ) do
         if not ply:GetNWBool( "CFC_PvP_Mode", false ) then
-            table.insert( builders, ply )
+            table.insert( builders, plywrap(ply) )
         end
     end
 


### PR DESCRIPTION
Starfall currently lacks player methods for getting the Player and Weapon colors the same way E2 does. It just uses built-in Garry's Mod methods.