### PR TITLE
Add color to player:chatPrint()

### DIFF
--- a/lua/starfall/libs_sv/ply.lua
+++ b/lua/starfall/libs_sv/ply.lua
@@ -210,7 +210,6 @@ end
 -- @param ... printArgs Values to print. Colors before text will set the text color
 function player_methods:chatPrint( ... )
     checkPlyCorePerms( instance.player )
-    
     checktype( self, ply_meta )
     
     local args = {}


### PR DESCRIPTION
This PR changes chatPrint to accept any number of both colors and strings, similar to the default print function.