### PR TITLE
Fix incorrect setRunSpeed default value

### DIFF
--- a/lua/starfall/libs_sv/ply.lua
+++ b/lua/starfall/libs_sv/ply.lua
@@ -113,7 +113,7 @@ function player_methods:setCrouchSpeedMultiplier( walkSpeed )
     ply:SetCrouchedWalkSpeed( walkSpeed )
 end
 
---- Sets the running speed of a player. This is when you're holding SHIFT. Default value is 600.
+--- Sets the running speed of a player. This is when you're holding SHIFT. Default value is 400.
 -- @param number RunSpeed
 function player_methods:setRunSpeed( runSpeed )
     checkPlyCorePerms( instance.player )


### PR DESCRIPTION
setRunSpeed incorrectly states the default value is 600, while in reality, it is 400.