### PR TITLE
Remove defunct playercolor methods

### DIFF
--- a/lua/starfall/libs_sh/ply.lua
+++ b/lua/starfall/libs_sh/ply.lua
@@ -2,8 +2,6 @@ return function( instance )
 
 local checktype = instance.CheckType
 local player_methods = instance.Types.Player.Methods
-local colorwrap = instance.Types.Color.Wrap
-local weapon_methods = instance.Types.Weapon.Methods
 local ply_meta, punwrap = instance.Types.Player, instance.Types.Player.Unwrap
 local builtins_library = instance.env
 
@@ -60,24 +58,6 @@ function player_methods:getAmmo()
     local ply = getPly( self )
 
     return ply:GetAmmo()
-end
-
---- Gets a valid player's color.
--- @return The playermodel color of a given player
-function player_methods:getPlayerColor()
-    checktype( self, ply_meta )
-    local ply = getPly( self )
-
-    return colorwrap( ply:GetPlayerColor() )
-end
-
---- Gets a valid player's weapon color.
--- @return the phygun weapon color of a given player
-function player_methods:getWeaponColor()
-    checktype( self, ply_meta )
-    local ply = getPly( self )
-
-    return colorwrap( ply:GetWeaponColor() )
 end
 
 --- Gets the name (string ID) of an ammo, given an ID. Refer to the keys given from the Player:getAmmo() table for numeric IDs.


### PR DESCRIPTION
Removes defunct `Player:getPlayerColor()` and `Player:getWeaponColor()` functions.
They return Color objects, when these are supposed to be Vectors, and don't account for the 255/1 unit space change.
Getting weapon color [already exists in base starfall](<https://github.com/thegrb93/StarfallEx/blob/master/lua/starfall/libs_sh/players.lua#L461>) and player color is [soon to follow](<https://github.com/thegrb93/StarfallEx/pull/1604>).