### PR TITLE
Add client-side hook: DiscordMessage

### DIFF
--- a/lua/starfall/libs_cl/cfc_discord.lua
+++ b/lua/starfall/libs_cl/cfc_discord.lua
@@ -1,0 +1,13 @@
+
+--- Called when a user sends a message on the Discord relay.
+-- @client
+-- @name DiscordMessage
+-- @class hook
+-- @param string name The user's name 
+-- @param string message The user's message
+SF.hookAdd( "CFC_ChatTransit_RemoteMessageReceive", "DiscordMessage", function( _instance, addTextParams )
+    local user = string.sub( addTextParams[4], 2 ) -- Strip "@"
+    local message = string.sub( addTextParams[6], 3 ) -- Strip ": "
+
+    return true, { user, message }
+end )

--- a/lua/starfall/libs_cl/cfc_discord.lua
+++ b/lua/starfall/libs_cl/cfc_discord.lua
@@ -6,7 +6,7 @@
 -- @param string author The user's name
 -- @param Color color The user's color
 -- @param string message The user's message
-SF.hookAdd( "CFC_ChatTransit_RemoteMessageReceive", "DiscordMessage", function( instance, author, authorColor, message )
-    local color = instance.Types.Color.Wrap( authorColor )
-    return true, { author, color, message }
+SF.hookAdd( "CFC_ChatTransit_RemoteMessageReceive", "DiscordMessage", function( instance, remoteMessage )
+    local color = instance.Types.Color.Wrap( remoteMessage.authorColor )
+    return true, { remoteMessage.author, color, remoteMessage.message }
 end )

--- a/lua/starfall/libs_cl/cfc_discord.lua
+++ b/lua/starfall/libs_cl/cfc_discord.lua
@@ -3,11 +3,10 @@
 -- @client
 -- @name DiscordMessage
 -- @class hook
--- @param string name The user's name 
+-- @param string author The user's name
+-- @param Color color The user's color
 -- @param string message The user's message
-SF.hookAdd( "CFC_ChatTransit_RemoteMessageReceive", "DiscordMessage", function( _instance, addTextParams )
-    local user = string.sub( addTextParams[4], 2 ) -- Strip "@"
-    local message = string.sub( addTextParams[6], 3 ) -- Strip ": "
-
-    return true, { user, message }
+SF.hookAdd( "CFC_ChatTransit_RemoteMessageReceive", "DiscordMessage", function( instance, author, authorColor, message )
+    local color = instance.Types.Color.Wrap( authorColor )
+    return true, { author, color, message }
 end )


### PR DESCRIPTION
Passthrough the `CFC_ChatTransit_RemoteMessageReceive` hook (from CFC-Servers/cfc_chat_transit), with some modifications.
Instead of referencing the original `addTextParams` table, we get the user name and message content from it, stripping the characters used for prettifying `chat.addText`.